### PR TITLE
Update version in setup.py to 0.2.6 and add softmax option to Nested_…

### DIFF
--- a/VitLib_PyTorch/Network/Nested_U_Net.py
+++ b/VitLib_PyTorch/Network/Nested_U_Net.py
@@ -22,7 +22,7 @@ class VGGBlock(nn.Module):
         return out
 
 class Nested_U_Net(nn.Module):
-    def __init__(self, input_channels, out_classes, deepsupervision=False):
+    def __init__(self, input_channels, out_classes, deepsupervision=False, softmax=False):
         super().__init__()
 
         nb_filter = [32, 64, 128, 256, 512]
@@ -51,7 +51,10 @@ class Nested_U_Net(nn.Module):
 
         self.conv0_4 = VGGBlock(nb_filter[0]*4+nb_filter[1], nb_filter[0], nb_filter[0])
 
-        self.sigmoid = nn.Sigmoid()
+        if softmax:
+            self.sigmoid = nn.Softmax(dim=1)
+        else:
+            self.sigmoid = nn.Sigmoid()
         if self.deepsupervision:
             self.final1 = nn.Conv2d(nb_filter[0], out_classes, kernel_size=1)
             self.final2 = nn.Conv2d(nb_filter[0], out_classes, kernel_size=1)

--- a/VitLib_PyTorch/Network/U_Net.py
+++ b/VitLib_PyTorch/Network/U_Net.py
@@ -59,10 +59,13 @@ class UP_Block(nn.Module):
         return out
 
 class Out_Block(nn.Module):
-    def __init__(self, in_channnel, out_channel):
+    def __init__(self, in_channnel, out_channel, softmax=False):
         super(Out_Block, self).__init__()
         self.conv = nn.Conv2d(in_channnel, out_channel, 1, bias=False)
-        self.sigmoid = nn.Sigmoid()
+        if softmax:        
+            self.sigmoid = nn.Softmax(dim=1)
+        else:
+            self.sigmoid = nn.Sigmoid()
 
     def forward(self, x):
         out = self.conv(x)
@@ -70,7 +73,7 @@ class Out_Block(nn.Module):
         return out
 
 class U_Net(nn.Module):
-    def __init__(self, in_channel, out_classes, bilinear=True):
+    def __init__(self, in_channel, out_classes, bilinear=True, softmax=False):
         super(U_Net,self).__init__()
         self.Conv1 = Conv_Block(in_channel, 64) #128x128xin_channel => #128x128x64
         self.Block1 = Down_Block(64, 128)       # => #64x64x128
@@ -81,7 +84,7 @@ class U_Net(nn.Module):
         self.Block6 = UP_Block(512, 128, bilinear=bilinear)
         self.Block7 = UP_Block(256, 64, bilinear=bilinear)
         self.Block8 = UP_Block(128, 64, bilinear=bilinear)
-        self.Conv2 = Out_Block(64,out_classes)
+        self.Conv2 = Out_Block(64,out_classes, softmax=softmax)
 
     def forward(self, x):
         x1 = self.Conv1(x)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup_kwargs = {
         "name": "VitLib_PyTorch",
-        "version": "0.2.5",
+        "version": "0.2.6",
         "description": "",
         "author": "Kotetsu0000",
         'install_requires' : [


### PR DESCRIPTION
This pull request includes several important updates to the `VitLib_PyTorch` library, primarily focused on adding softmax functionality to the `Nested_U_Net` and `U_Net` classes, as well as updating the package version.

### Enhancements to Network Classes:

* [`VitLib_PyTorch/Network/Nested_U_Net.py`](diffhunk://#diff-3bf53d8870aecf0c8385d702547f6aa600730534180649a1a2c7983bc2f30f3dL25-R25): Added a `softmax` parameter to the `__init__` method, allowing the choice between `Softmax` and `Sigmoid` activation functions. [[1]](diffhunk://#diff-3bf53d8870aecf0c8385d702547f6aa600730534180649a1a2c7983bc2f30f3dL25-R25) [[2]](diffhunk://#diff-3bf53d8870aecf0c8385d702547f6aa600730534180649a1a2c7983bc2f30f3dR54-R56)

* [`VitLib_PyTorch/Network/U_Net.py`](diffhunk://#diff-e8a2e9a28e1585476a248bc93505906404072ff064f8957077a3cfe6154aabb0L62-R67): Introduced a `softmax` parameter to the `__init__` method of both `Out_Block` and `U_Net` classes, enabling the selection of `Softmax` or `Sigmoid` activation functions. [[1]](diffhunk://#diff-e8a2e9a28e1585476a248bc93505906404072ff064f8957077a3cfe6154aabb0L62-R67) [[2]](diffhunk://#diff-e8a2e9a28e1585476a248bc93505906404072ff064f8957077a3cfe6154aabb0L73-R76) [[3]](diffhunk://#diff-e8a2e9a28e1585476a248bc93505906404072ff064f8957077a3cfe6154aabb0L84-R87)

### Version Update:

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L5-R5): Updated the package version from `0.2.5` to `0.2.6`.…U_Net and U_Net classes